### PR TITLE
Test proper timestamps

### DIFF
--- a/test/test_real_world.cpp
+++ b/test/test_real_world.cpp
@@ -56,13 +56,10 @@ int main()
             return 1;
         }
 
+        printf("[TIMESTAMP: %f s] ", responseFrame.timestamp / 1000.0);
+
         botSpeak_deserialize(readData, &numberElements, sizeof(float), responseFrame.data, responseFrame.dataLength);
         printf("Deserialized Data: ");
-        for (uint8_t i = 0; i < numberElements; ++i)
-        {
-            printf("%f ", readData[i]);
-        }
-
         for (uint8_t i = 0; i < numberElements; ++i)
         {
             printf("%f ", readData[i]);


### PR DESCRIPTION
The STM32 will now publish timestamps. Added test for this feature on the PC/SBC.

Please see https://github.com/eccentricOrange/int-brain-stm32/pull/6